### PR TITLE
add all void elements to `noClosing` list.

### DIFF
--- a/Text/HTML/Parser.hs
+++ b/Text/HTML/Parser.hs
@@ -55,7 +55,7 @@ type AttrValue = Text
 
 -- | An HTML token
 data Token
-  -- | An opening tag. Attribute ordering is arbitrary.
+  -- | An opening tag. Attribute ordering is arbitrary. Void elements have a 'TagOpen' but no corresponding 'TagClose'. See 'Text.HTML.Tree.nonClosing'.
   = TagOpen !TagName [Attr]
   -- | A self-closing tag.
   | TagSelfClose !TagName [Attr]

--- a/Text/HTML/Tree.hs
+++ b/Text/HTML/Tree.hs
@@ -34,7 +34,7 @@ tokensToForest = f (PStack [] [])
         Doctype _       -> f (pushFlatSibling t pstack) ts
 
 nonClosing :: [Text]
-nonClosing = ["br", "hr", "img"]
+nonClosing = ["br", "hr", "img", "meta", "area", "base", "col", "command", "embed", "input", "keygen", "link", "param", "source", "track", "wbr"]
 
 data ParseTokenForestError =
     ParseTokenForestErrorBracketMismatch PStack (Maybe Token)

--- a/Text/HTML/Tree.hs
+++ b/Text/HTML/Tree.hs
@@ -16,7 +16,13 @@ import           Data.Text (Text)
 import           Data.Tree
 import           Text.HTML.Parser
 
-
+-- | construct a 'Forest' from a 'Token' list.
+--
+-- This code correctly handles void elements. Void elements are required to have a start tag and must not have an end tag. See 'nonClosing'.
+--
+-- This code does __not__ correctly handle optional tags. It assumes all optional start and end tags are present.
+--
+-- <https:\/\/www.w3.org\/TR\/html52\/syntax.html#optional-tags>
 tokensToForest :: [Token] -> Either ParseTokenForestError (Forest Token)
 tokensToForest = f (PStack [] [])
   where
@@ -33,8 +39,15 @@ tokensToForest = f (PStack [] [])
         Comment _       -> f (pushFlatSibling t pstack) ts
         Doctype _       -> f (pushFlatSibling t pstack) ts
 
+-- | void elements which must not have an end tag
+--
+-- This list does not include the obsolete @\<command\>@ and @\<keygen\>@ elements.
+--
+-- @ nonClosing = ["br", "hr", "img", "meta", "area", "base", "col", "embed", "input", "link", "param", "source", "track", "wbr"] @
+--
+-- <https:\/\/www.w3.org\/TR\/html52\/syntax.html#void-elements>
 nonClosing :: [Text]
-nonClosing = ["br", "hr", "img", "meta", "area", "base", "col", "command", "embed", "input", "keygen", "link", "param", "source", "track", "wbr"]
+nonClosing = ["br", "hr", "img", "meta", "area", "base", "col", "embed", "input", "link", "param", "source", "track", "wbr"]
 
 data ParseTokenForestError =
     ParseTokenForestErrorBracketMismatch PStack (Maybe Token)
@@ -58,10 +71,15 @@ popParent n pstack
 pushFlatSibling :: Token -> PStack -> PStack
 pushFlatSibling t (PStack ss ps) = PStack (Node t [] : ss) ps
 
-
+-- | convert a 'Forest' of 'Token' into a list of 'Token'.
+--
+-- This code correctly handles void elements. Void elements are required to have a start tag and must not have an end tag. See 'nonClosing'.
 tokensFromForest :: Forest Token -> [Token]
 tokensFromForest = mconcat . fmap tokensFromTree
 
+-- | convert a 'Tree' of 'Token' into a list of 'Token'.
+--
+-- This code correctly handles void elements. Void elements are required to have a start tag and must not have an end tag. See 'nonClosing'.
 tokensFromTree :: Tree Token -> [Token]
 tokensFromTree (Node o@(TagOpen n _) ts) | n `notElem` nonClosing
     = [o] <> tokensFromForest ts <> [TagClose n]


### PR DESCRIPTION
the `nonClosing` list previously contained three popular void elements (`<br>`,`<hr>`, and `<img>`). But not other common ones such as `<meta>` and `<input>`. I updated the list to include all void elements listed here,

https://www.w3.org/TR/html52/syntax.html#void-elements

I did not include the now obsolete `<command>` and `<keygen>` elements.

This potentially closes this issue,

https://github.com/bgamari/html-parse/issues/15

I've also noted that the tree parser does *not* correctly handle optional start and end tags,

https://www.w3.org/TR/html52/syntax.html#optional-tags

That is a bug, but not one I care about.


