### PR TITLE
Add \r to the isWhitespace predicate

### DIFF
--- a/src/Text/HTML/Parser.hs
+++ b/src/Text/HTML/Parser.hs
@@ -139,6 +139,7 @@ isWhitespace :: Char -> Bool
 isWhitespace '\x09' = True
 isWhitespace '\x0a' = True
 isWhitespace '\x0c' = True
+isWhitespace '\x0d' = True
 isWhitespace ' '    = True
 isWhitespace _      = False
 


### PR DESCRIPTION
This change has been verified in our web application and it enables cut and paste from Microsoft Word.